### PR TITLE
Specify HTML for treesitter in is_available

### DIFF
--- a/lua/html-css/init.lua
+++ b/lua/html-css/init.lua
@@ -159,7 +159,7 @@ function Source:is_available()
 		return false
 	end
 
-	local inside_quotes = ts.get_node({ bfnr = 0 })
+	local inside_quotes = ts.get_node({ bfnr = 0, lang = "html" })
 
 	if inside_quotes == nil then
 		return false


### PR DESCRIPTION
Many template languages will have HTML but with a different filetype or even a composite filetype ex: php.html. Specify HTML here since the user gave the filetype with the intent that it contains HTML.