### PR TITLE
fix(cache): add missing buffer validation in cache:get_ids

### DIFF
--- a/lua/html-css/cache.lua
+++ b/lua/html-css/cache.lua
@@ -29,6 +29,10 @@ end
 ---@param bufnr integer
 ---@return Selector[]
 function cache:get_ids(bufnr)
+    if not self._buffers[bufnr] then
+        return {}
+    end
+    
     local buffer_sources = self._buffers[bufnr]._sources or {}
     local ids = {}
 


### PR DESCRIPTION
Fixes a 'attempt to index a nil value' crash in html-css/cache.lua:32.

The function `cache:get_ids(bufnr)` was missing an early return check for non-existent buffers in `self._buffers[bufnr]`, unlike `cache:get_classes`. This caused crashes when autocomplete was requested on unloaded or UI floating buffers.