### PR TITLE
fix: resolve completion context through injected language trees

### DIFF
--- a/lua/html-css/lsp.lua
+++ b/lua/html-css/lsp.lua
@@ -3,6 +3,39 @@ local utils = require "html-css.utils"
 
 local LSP = {}
 
+--- Finds the smallest node at `position`, resolving through injected language
+--- trees (e.g. the HTML region injected into a Twig/Blade/Vue buffer) instead
+--- of forcing a fresh, unscoped parse of the whole buffer as `lang = "html"`.
+--- The latter breaks on any non-HTML template syntax elsewhere in the file
+--- (has_error == true) and can fail to resolve a node at all, even at
+--- positions the injected tree parses perfectly fine.
+---@param bufnr integer
+---@param position { line: integer, character: integer }
+---@return TSNode|nil
+local function get_context_node(bufnr, position)
+    local ok, parser = pcall(vim.treesitter.get_parser, bufnr)
+    if not ok or not parser then
+        return nil
+    end
+
+    parser:parse(true)
+
+    local range = { position.line, position.character, position.line, position.character }
+    local lang_tree = parser:language_for_range(range)
+
+    for _, tree in ipairs(lang_tree:trees()) do
+        local sr, sc, er, ec = tree:root():range()
+        local after_start = position.line > sr or (position.line == sr and position.character >= sc)
+        local before_end = position.line < er or (position.line == er and position.character <= ec)
+        if after_start and before_end then
+            return tree:root()
+                :named_descendant_for_range(position.line, position.character, position.line, position.character)
+        end
+    end
+
+    return nil
+end
+
 local function create_server(dispatchers)
     local closing = false
     local srv = {}
@@ -47,7 +80,7 @@ local function create_server(dispatchers)
             end
 
             local context = nil
-            local node = vim.treesitter.get_node({ lang = "html", pos = { position.line, position.character } })
+            local node = get_context_node(bufnr, position)
 
             while node do
                 if node:type() == "attribute" or node:type() == "jsx_attribute" then
@@ -133,7 +166,7 @@ local function create_server(dispatchers)
 
             local context = nil
             local word = nil
-            local node = vim.treesitter.get_node({ lang = "html", pos = { position.line, position.character } })
+            local node = get_context_node(bufnr, position)
 
             -- Small helper to traverse up and check attributes
             local curr = node
@@ -200,7 +233,7 @@ local function create_server(dispatchers)
             -- Identify word at cursor and context
             local context = nil
             local word = nil
-            local node = vim.treesitter.get_node({ lang = "html", pos = { position.line, position.character } })
+            local node = get_context_node(bufnr, position)
 
             -- Helper to traverse up and check attributes (reused from definition)
             local curr = node


### PR DESCRIPTION
vim.treesitter.get_node({ lang = "html", ... }) forces a fresh, unscoped parse of the entire buffer as standalone HTML instead of reusing the language's own injected HTML region (e.g. Twig's injections.scm). For any buffer that mixes real HTML with non-HTML template syntax (Twig, Blade, Vue, JSX/TSX), that from-scratch parse comes back with parse errors and frequently fails to resolve a node at all, even at positions the injected tree parses cleanly.

Replace it with get_context_node(), which asks the buffer's actual parser which (possibly injected) language tree covers the cursor via language_for_range(), then resolves the node within that tree. Falls back identically to the old behavior for plain .html buffers, since there the 'injected' tree is just the top-level parser itself.

Verified against a 727-line .html.twig file: previously 0/175 class= attribute positions resolved a node; now 175/175 return completion items through the real LSP completion request path.

Fixes Jezda1337/nvim-html-css#65